### PR TITLE
add DataCite and Dublin Core to crosswalk

### DIFF
--- a/crosswalk.csv
+++ b/crosswalk.csv
@@ -1,36 +1,36 @@
-Concept,CodeMeta Field,Zenodo,Figshare,code.jsonld,Software Discovery Index,Software Ontology
-SoftwareTitle,title,title,Title,name,Software title,
-SoftwareIdentifier,identifier,id,?,citation,Persistent identifier,
-SoftwareAuthor,author,creators,Authors(s),author,Author names and affiliations,
-AuthorName, name,name,Name,name,-,
-AuthorId,id,-,id(internal id/ORCID),id(ORCID),-,
-AuthorEmail,email,-,-,email,-,
-AuthorAffiliation,affiliation,affiliation,-,-,-,
-UploadedBy,UploadedBy,?,-,-,-,
-ControlledTerm,ControlledTerm,communities,category,,-,
-ObjectType,ObjectType,upload_type,file_type,type,-,
-Tags,Tags,keywords,tags,keywords,-,
-Description,Description,description/notes,Description,description,Human-readable synopsis,
-RelatedLink,RelatedLink,related_identifiers,links,codeRepository,-,
-CodeRepositoryLink,CodeRepository,-,-,codeRepository,Links to code repository,
-ReadmeLink,Readme,-,-,-,-,
-BuildLink,BuildInstructions,-,-,-,-,
-CILink,ContIntegration,-,-,-,-,
-IssueLink,IssueTracker,-,-,-,-,
-AccessList,AccessList,access_right(public/embargo/private),access(private/public),-,-,
-License,License,license,License,license,Software license,
-datePublished,datePublished,publication_date,date_retrieved,-,-,
-dateCreated,dateCreated,-,-,dateCreated,-,
-dateModified,dateModified,-,-,-,-,
-EmbargoDate,EmbargoDate,embargo_date,-,-,-,
-Inputs,Inputs,-,-,-,Formats for data inputs and outputs,
-Outputs,Outputs,-,-,-,Formats for data inputs and outputs,
-Function,Function,-,-,-,Terms to describe software objectives or functions,
-Dependency,Dependency,-,-,-,"Platform, environment, and dependencies",
-TestCoverage,TestCoverage,-,-,-,-,
-DocsCoverage,DocsCoverage,-,-,-,-,
-IsAutomated,IsAutomatedBuild,-,-,-,-,
-Package,Package,filename,-,-,-,
-ZippedCodeLink,ZippedCode,-,file,-,-,
-Version,-,-,-,-,Software version,
-GrantsAndPubsLink,-,-,-,-,Associated grants and publications,
+Concept,CodeMeta Field,Zenodo,Figshare,code.jsonld,Software Discovery Index,Software Ontology,DataCite,Dublin Core
+SoftwareTitle,title,title,Title,name,Software title,,Title,title
+SoftwareIdentifier,identifier,id,?,citation,Persistent identifier,,Identifier,identifier
+SoftwareAuthor,author,creators,Authors(s),author,Author names and affiliations,,Creator,creator
+AuthorName, name,name,Name,name,-,,creatorName,-
+AuthorId,id,-,id(internal id/ORCID),id(ORCID),-,,nameIdentifier,-
+AuthorEmail,email,-,-,email,-,,-,-
+AuthorAffiliation,affiliation,affiliation,-,-,-,,affiliation,-
+UploadedBy,UploadedBy,?,-,-,-,,-,-
+ControlledTerm,ControlledTerm,communities,category,,-,,-,-
+ObjectType,ObjectType,upload_type,file_type,type,-,,ResourceType,type
+Tags,Tags,keywords,tags,keywords,-,,Subject,subject
+Description,Description,description/notes,Description,description,Human-readable synopsis,,Description,description
+RelatedLink,RelatedLink,related_identifiers,links,codeRepository,-,,RelatedIdentifier,relation
+CodeRepositoryLink,CodeRepository,-,-,codeRepository,Links to code repository,,-,-
+ReadmeLink,Readme,-,-,-,-,,RelatedIdentifier(relationType = isDocumentedBy),-
+BuildLink,BuildInstructions,-,-,-,-,,-,-
+CILink,ContIntegration,-,-,-,-,,-,-
+IssueLink,IssueTracker,-,-,-,-,,-,-
+AccessList,AccessList,access_right(public/embargo/private),access(private/public),-,-,,-,-
+License,License,license,License,license,Software license,,Rights,license
+datePublished,datePublished,publication_date,date_retrieved,-,-,,PublicationYear,date
+dateCreated,dateCreated,-,-,dateCreated,-,,Date(dateType = Created),created
+dateModified,dateModified,-,-,-,-,,Date(dateType = Updated),modified
+EmbargoDate,EmbargoDate,embargo_date,-,-,-,,Date(dateType = Available),available
+Inputs,Inputs,-,-,-,Formats for data inputs and outputs,,-,-
+Outputs,Outputs,-,-,-,Formats for data inputs and outputs,,-,-
+Function,Function,-,-,-,Terms to describe software objectives or functions,,-,-
+Dependency,Dependency,-,-,-,"Platform, environment, and dependencies",,-,requires
+TestCoverage,TestCoverage,-,-,-,-,,-,-
+DocsCoverage,DocsCoverage,-,-,-,-,,-,-
+IsAutomated,IsAutomatedBuild,-,-,-,-,,-,-
+Package,Package,filename,-,-,-,,-,-
+ZippedCodeLink,ZippedCode,-,file,-,-,,-,-
+Version,-,-,-,-,Software version,,Version,-
+GrantsAndPubsLink,-,-,-,-,Associated grants and publications,,-,-


### PR DESCRIPTION
Greetings,
I added columns for DataCite and Dublin Core metadata schemas to the crosswalk. DataCite has already been discussed (issue #13), and I definitely agree that it's a good idea. Dublin Core is pretty trivial, but I think that it could be useful for getting software into researcher's normal manuscript-writing workflow (e.g., facilitating import into reference managers).